### PR TITLE
fixing missing resource type in auditors

### DIFF
--- a/sbauditor/auditors/aws/AMI_Auditor.py
+++ b/sbauditor/auditors/aws/AMI_Auditor.py
@@ -56,7 +56,7 @@ def public_ami_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartitio
                 "ProductFields": {"Product Name": "Day2SecurityBot"},
                 "Resources": [
                     {
-                        "Type": "Other",
+                        "Type": "AwsEc2Image",
                         "Id": amiArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
@@ -113,7 +113,7 @@ def public_ami_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartitio
                 "ProductFields": {"Product Name": "Day2SecurityBot"},
                 "Resources": [
                     {
-                        "Type": "Other",
+                        "Type": "AwsEc2Image",
                         "Id": amiArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
@@ -189,7 +189,7 @@ def encrypted_ami_check(cache: dict, awsAccountId: str, awsRegion: str, awsParti
                     "ProductFields": {"Product Name": "Day2SecurityBot"},
                     "Resources": [
                         {
-                            "Type": "Other",
+                            "Type": "AwsEc2Image",
                             "Id": amiArn,
                             "Partition": awsPartition,
                             "Region": awsRegion,
@@ -240,7 +240,7 @@ def encrypted_ami_check(cache: dict, awsAccountId: str, awsRegion: str, awsParti
                     "ProductFields": {"Product Name": "Day2SecurityBot"},
                     "Resources": [
                         {
-                            "Type": "Other",
+                            "Type": "AwsEc2Image",
                             "Id": amiArn,
                             "Partition": awsPartition,
                             "Region": awsRegion,

--- a/sbauditor/auditors/aws/AWS_AppMesh_Auditor.py
+++ b/sbauditor/auditors/aws/AWS_AppMesh_Auditor.py
@@ -55,7 +55,7 @@ def appmesh_mesh_egress_check(
                     "ProductFields": {"Product Name": "Day2SecurityBot"},
                     "Resources": [
                         {
-                            "Type": "AwsAppMeshMesh",
+                            "Type": "AWSAppMeshServiceMesh",
                             "Id": meshArn,
                             "Partition": awsPartition,
                             "Region": awsRegion,
@@ -109,7 +109,7 @@ def appmesh_mesh_egress_check(
                     "ProductFields": {"Product Name": "Day2SecurityBot"},
                     "Resources": [
                         {
-                            "Type": "AwsAppMeshMesh",
+                            "Type": "AWSAppMeshServiceMesh",
                             "Id": meshArn,
                             "Partition": awsPartition,
                             "Region": awsRegion,

--- a/sbauditor/auditors/aws/AWS_AppMesh_Auditor.py
+++ b/sbauditor/auditors/aws/AWS_AppMesh_Auditor.py
@@ -55,7 +55,7 @@ def appmesh_mesh_egress_check(
                     "ProductFields": {"Product Name": "Day2SecurityBot"},
                     "Resources": [
                         {
-                            "Type": "Other",
+                            "Type": "AwsAppMeshMesh",
                             "Id": meshArn,
                             "Partition": awsPartition,
                             "Region": awsRegion,
@@ -109,7 +109,7 @@ def appmesh_mesh_egress_check(
                     "ProductFields": {"Product Name": "Day2SecurityBot"},
                     "Resources": [
                         {
-                            "Type": "Other",
+                            "Type": "AwsAppMeshMesh",
                             "Id": meshArn,
                             "Partition": awsPartition,
                             "Region": awsRegion,
@@ -195,7 +195,7 @@ def appmesh_virt_node_backed_default_tls_policy_check(
                             "ProductFields": {"Product Name": "Day2SecurityBot"},
                             "Resources": [
                                 {
-                                    "Type": "Other",
+                                    "Type": "AwsAppMeshVirtualNode",
                                     "Id": nodeArn,
                                     "Partition": awsPartition,
                                     "Region": awsRegion,
@@ -263,7 +263,7 @@ def appmesh_virt_node_backed_default_tls_policy_check(
                                 "ProductFields": {"Product Name": "Day2SecurityBot"},
                                 "Resources": [
                                     {
-                                        "Type": "Other",
+                                        "Type": "AwsAppMeshVirtualNode",
                                         "Id": nodeArn,
                                         "Partition": awsPartition,
                                         "Region": awsRegion,
@@ -325,7 +325,7 @@ def appmesh_virt_node_backed_default_tls_policy_check(
                                 "ProductFields": {"Product Name": "Day2SecurityBot"},
                                 "Resources": [
                                     {
-                                        "Type": "Other",
+                                        "Type": "AwsAppMeshVirtualNode",
                                         "Id": nodeArn,
                                         "Partition": awsPartition,
                                         "Region": awsRegion,
@@ -418,7 +418,7 @@ def appmesh_virt_node_listener_strict_tls_check(
                                 "ProductFields": {"Product Name": "Day2SecurityBot"},
                                 "Resources": [
                                     {
-                                        "Type": "Other",
+                                        "Type": "AwsAppMeshVirtualNode",
                                         "Id": nodeArn,
                                         "Partition": awsPartition,
                                         "Region": awsRegion,
@@ -481,7 +481,7 @@ def appmesh_virt_node_listener_strict_tls_check(
                                 "ProductFields": {"Product Name": "Day2SecurityBot"},
                                 "Resources": [
                                     {
-                                        "Type": "Other",
+                                        "Type": "AwsAppMeshVirtualNode",
                                         "Id": nodeArn,
                                         "Partition": awsPartition,
                                         "Region": awsRegion,
@@ -570,7 +570,7 @@ def appmesh_logging_check(
                         "ProductFields": {"Product Name": "Day2SecurityBot"},
                         "Resources": [
                             {
-                                "Type": "Other",
+                                "Type": "AwsAppMeshVirtualNode",
                                 "Id": nodeArn,
                                 "Partition": awsPartition,
                                 "Region": awsRegion,
@@ -633,7 +633,7 @@ def appmesh_logging_check(
                             "ProductFields": {"Product Name": "Day2SecurityBot"},
                             "Resources": [
                                 {
-                                    "Type": "Other",
+                                    "Type": "AwsAppMeshVirtualNode",
                                     "Id": nodeArn,
                                     "Partition": awsPartition,
                                     "Region": awsRegion,

--- a/sbauditor/auditors/aws/AWS_Directory_Service_Auditor.py
+++ b/sbauditor/auditors/aws/AWS_Directory_Service_Auditor.py
@@ -56,7 +56,7 @@ def directory_service_radius_check(
                     "ProductFields": {"Product Name": "Day2SecurityBot"},
                     "Resources": [
                         {
-                            "Type": "Other",
+                            "Type": "AwsDirectoryServiceDirectory",
                             "Id": directoryArn,
                             "Partition": awsPartition,
                             "Region": awsRegion,
@@ -115,7 +115,7 @@ def directory_service_radius_check(
                     "ProductFields": {"Product Name": "Day2SecurityBot"},
                     "Resources": [
                         {
-                            "Type": "Other",
+                            "Type": "AwsDirectoryServiceDirectory",
                             "Id": directoryArn,
                             "Partition": awsPartition,
                             "Region": awsRegion,
@@ -191,7 +191,7 @@ def directory_service_cloudwatch_logs_check(
                 "ProductFields": {"Product Name": "Day2SecurityBot"},
                 "Resources": [
                     {
-                        "Type": "Other",
+                        "Type": "AwsDirectoryServiceDirectory",
                         "Id": directoryArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
@@ -243,7 +243,7 @@ def directory_service_cloudwatch_logs_check(
                 "ProductFields": {"Product Name": "Day2SecurityBot"},
                 "Resources": [
                     {
-                        "Type": "Other",
+                        "Type": "AwsDirectoryServiceDirectory",
                         "Id": directoryArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,

--- a/sbauditor/auditors/aws/AWS_License_Manager_Auditor.py
+++ b/sbauditor/auditors/aws/AWS_License_Manager_Auditor.py
@@ -61,7 +61,7 @@ def license_manager_hard_count_check(
                             "ProductFields": {"Product Name": "Day2SecurityBot"},
                             "Resources": [
                                 {
-                                    "Type": "Other",
+                                    "Type": "AwsLicenseManagerLicenseConfiguration",
                                     "Id": liscConfigArn,
                                     "Partition": awsPartition,
                                     "Region": awsRegion,
@@ -118,7 +118,7 @@ def license_manager_hard_count_check(
                             "ProductFields": {"Product Name": "Day2SecurityBot"},
                             "Resources": [
                                 {
-                                    "Type": "Other",
+                                    "Type": "AwsLicenseManagerLicenseConfiguration",
                                     "Id": liscConfigArn,
                                     "Partition": awsPartition,
                                     "Region": awsRegion,

--- a/sbauditor/auditors/aws/AWS_Secrets_Manager_Auditor.py
+++ b/sbauditor/auditors/aws/AWS_Secrets_Manager_Auditor.py
@@ -52,11 +52,11 @@ def secret_age_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartitio
                 "ProductFields": {"Product Name": "Day2SecurityBot"},
                 "Resources": [
                     {
-                        "Type": "Other",
+                        "Type": "AwsSecretsManagerSecret",
                         "Id": secretArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
-                        "Details": {"Other": {"secretName": secretName}},
+                        "Details": {"AwsSecretsManagerSecret": {"Name": secretName}},
                     }
                 ],
                 "Compliance": {
@@ -116,11 +116,11 @@ def secret_age_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartitio
                 "ProductFields": {"Product Name": "Day2SecurityBot"},
                 "Resources": [
                     {
-                        "Type": "Other",
+                        "Type": "AwsSecretsManagerSecret",
                         "Id": secretArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
-                        "Details": {"Other": {"secretName": secretName}},
+                        "Details": {"AwsSecretsManagerSecret": {"Name": secretName}},
                     }
                 ],
                 "Compliance": {
@@ -195,11 +195,11 @@ def secret_changed_in_last_90_check(
                 "ProductFields": {"Product Name": "Day2SecurityBot"},
                 "Resources": [
                     {
-                        "Type": "Other",
+                        "Type": "AwsSecretsManagerSecret",
                         "Id": secretArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
-                        "Details": {"Other": {"secretName": secretName}},
+                        "Details": {"AwsSecretsManagerSecret": {"Name": secretName}},
                     }
                 ],
                 "Compliance": {
@@ -260,11 +260,11 @@ def secret_changed_in_last_90_check(
                 "ProductFields": {"Product Name": "Day2SecurityBot"},
                 "Resources": [
                     {
-                        "Type": "Other",
+                        "Type": "AwsSecretsManagerSecret",
                         "Id": secretArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
-                        "Details": {"Other": {"secretName": secretName}},
+                        "Details": {"AwsSecretsManagerSecret": {"Name": secretName}},
                     }
                 ],
                 "Compliance": {

--- a/sbauditor/auditors/aws/Amazon_AppStream_Auditor.py
+++ b/sbauditor/auditors/aws/Amazon_AppStream_Auditor.py
@@ -180,7 +180,7 @@ def public_image_check(cache: dict, awsAccountId: str, awsRegion: str, awsPartit
             "ProductFields": {"Product Name": "SecurityBot"},
             "Resources": [
                 {
-                    "Type": "Other",
+                    "Type": "AwsAppStreamImage",
                     "Id": imageArn,
                     "Partition": awsPartition,
                     "Region": awsRegion,
@@ -253,7 +253,7 @@ def compromise_appstream_user_check(
                 "ProductFields": {"Product Name": "SecurityBot"},
                 "Resources": [
                     {
-                        "Type": "Other",
+                        "Type": "AwsAppStreamUser",
                         "Id": userArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
@@ -315,7 +315,7 @@ def compromise_appstream_user_check(
                 "ProductFields": {"Product Name": "SecurityBot"},
                 "Resources": [
                     {
-                        "Type": "Other",
+                        "Type": "AwsAppStreamUser",
                         "Id": userArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
@@ -391,7 +391,7 @@ def userpool_auth_check(cache: dict, awsAccountId: str, awsRegion: str, awsParti
                 "ProductFields": {"Product Name": "SecurityBot"},
                 "Resources": [
                     {
-                        "Type": "Other",
+                        "Type": "AwsAppStreamUser",
                         "Id": userArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
@@ -450,7 +450,7 @@ def userpool_auth_check(cache: dict, awsAccountId: str, awsRegion: str, awsParti
                 "ProductFields": {"Product Name": "SecurityBot"},
                 "Resources": [
                     {
-                        "Type": "Other",
+                        "Type": "AwsAppStreamUser",
                         "Id": userArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,

--- a/sbauditor/auditors/aws/Amazon_DocumentDB_Auditor.py
+++ b/sbauditor/auditors/aws/Amazon_DocumentDB_Auditor.py
@@ -669,7 +669,7 @@ def documentdb_parameter_group_audit_log_check(
                             "ProductFields": {"Product Name": "Day2SecurityBot"},
                             "Resources": [
                                 {
-                                    "Type": "Other",
+                                    "Type": "AwsDocumentDbParameterGroup",
                                     "Id": parameterGroupArn,
                                     "Partition": awsPartition,
                                     "Region": awsRegion,
@@ -726,7 +726,7 @@ def documentdb_parameter_group_audit_log_check(
                             "ProductFields": {"Product Name": "Day2SecurityBot"},
                             "Resources": [
                                 {
-                                    "Type": "Other",
+                                    "Type": "AwsDocumentDbParameterGroup",
                                     "Id": parameterGroupArn,
                                     "Partition": awsPartition,
                                     "Region": awsRegion,
@@ -811,7 +811,7 @@ def documentdb_parameter_group_tls_enforcement_check(
                             "ProductFields": {"Product Name": "Day2SecurityBot"},
                             "Resources": [
                                 {
-                                    "Type": "Other",
+                                    "Type": "AwsDocumentDbParameterGroup",
                                     "Id": parameterGroupArn,
                                     "Partition": awsPartition,
                                     "Region": awsRegion,
@@ -869,7 +869,7 @@ def documentdb_parameter_group_tls_enforcement_check(
                             "ProductFields": {"Product Name": "Day2SecurityBot"},
                             "Resources": [
                                 {
-                                    "Type": "Other",
+                                    "Type": "AwsDocumentDbParameterGroup",
                                     "Id": parameterGroupArn,
                                     "Partition": awsPartition,
                                     "Region": awsRegion,
@@ -949,7 +949,7 @@ def documentdb_cluster_snapshot_encryption_check(
                     "ProductFields": {"Product Name": "Day2SecurityBot"},
                     "Resources": [
                         {
-                            "Type": "Other",
+                            "Type": "AwsDocumentDbSnapshot",
                             "Id": clusterSnapshotArn,
                             "Partition": awsPartition,
                             "Region": awsRegion,
@@ -1000,7 +1000,7 @@ def documentdb_cluster_snapshot_encryption_check(
                     "ProductFields": {"Product Name": "Day2SecurityBot"},
                     "Resources": [
                         {
-                            "Type": "Other",
+                            "Type": "AwsDocumentDbSnapshot",
                             "Id": clusterSnapshotArn,
                             "Partition": awsPartition,
                             "Region": awsRegion,
@@ -1079,7 +1079,7 @@ def documentdb_cluster_snapshot_public_share_check(
                             "ProductFields": {"Product Name": "Day2SecurityBot"},
                             "Resources": [
                                 {
-                                    "Type": "Other",
+                                    "Type": "AwsDocumentDbSnapshot",
                                     "Id": clusterSnapshotArn,
                                     "Partition": awsPartition,
                                     "Region": awsRegion,
@@ -1137,7 +1137,7 @@ def documentdb_cluster_snapshot_public_share_check(
                             "ProductFields": {"Product Name": "Day2SecurityBot"},
                             "Resources": [
                                 {
-                                    "Type": "Other",
+                                    "Type": "AwsDocumentDbSnapshot",
                                     "Id": clusterSnapshotArn,
                                     "Partition": awsPartition,
                                     "Region": awsRegion,

--- a/sbauditor/auditors/aws/Amazon_Neptune_Auditor.py
+++ b/sbauditor/auditors/aws/Amazon_Neptune_Auditor.py
@@ -56,7 +56,7 @@ def neptune_instance_multi_az_check(
                 "ProductFields": {"Product Name": "Day2SecurityBot"},
                 "Resources": [
                     {
-                        "Type": "Other",
+                        "Type": "AwsNeptuneInstance",
                         "Id": neptuneInstanceArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
@@ -110,7 +110,7 @@ def neptune_instance_multi_az_check(
                 "ProductFields": {"Product Name": "Day2SecurityBot"},
                 "Resources": [
                     {
-                        "Type": "Other",
+                        "Type": "AwsNeptuneInstance",
                         "Id": neptuneInstanceArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
@@ -166,7 +166,7 @@ def neptune_instance_storage_encryption_check(
                 "UpdatedAt": iso8601Time,
                 "Severity": {"Label": "HIGH"},
                 "Confidence": 99,
-                "Title": "[Neptune.2] Neptune database instace storage should be encrypted",
+                "Title": "[Neptune.2] Neptune database instances storage should be encrypted",
                 "Description": "Neptune database instance "
                 + neptuneDbId
                 + " does not have storage encryption enabled. Refer to the remediation instructions to remediate this behavior",
@@ -179,7 +179,7 @@ def neptune_instance_storage_encryption_check(
                 "ProductFields": {"Product Name": "Day2SecurityBot"},
                 "Resources": [
                     {
-                        "Type": "Other",
+                        "Type": "AwsNeptuneInstance",
                         "Id": neptuneInstanceArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
@@ -217,7 +217,7 @@ def neptune_instance_storage_encryption_check(
                 "UpdatedAt": iso8601Time,
                 "Severity": {"Label": "INFORMATIONAL"},
                 "Confidence": 99,
-                "Title": "[Neptune.2] Neptune database instace storage should be encrypted",
+                "Title": "[Neptune.2] Neptune database instances storage should be encrypted",
                 "Description": "Neptune database instance "
                 + neptuneDbId
                 + " has storage encryption enabled.",
@@ -230,7 +230,7 @@ def neptune_instance_storage_encryption_check(
                 "ProductFields": {"Product Name": "Day2SecurityBot"},
                 "Resources": [
                     {
-                        "Type": "Other",
+                        "Type": "AwsNeptuneInstance",
                         "Id": neptuneInstanceArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
@@ -280,7 +280,7 @@ def neptune_instance_iam_authentication_check(
                 "UpdatedAt": iso8601Time,
                 "Severity": {"Label": "MEDIUM"},
                 "Confidence": 99,
-                "Title": "[Neptune.3] Neptune database instaces storage should use IAM Database Authentication",
+                "Title": "[Neptune.3] Neptune database instances storage should use IAM Database Authentication",
                 "Description": "Neptune database instance "
                 + neptuneDbId
                 + " does not use IAM Database Authentication. Refer to the remediation instructions to remediate this behavior",
@@ -293,7 +293,7 @@ def neptune_instance_iam_authentication_check(
                 "ProductFields": {"Product Name": "Day2SecurityBot"},
                 "Resources": [
                     {
-                        "Type": "Other",
+                        "Type": "AwsNeptuneInstance",
                         "Id": neptuneInstanceArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
@@ -342,7 +342,7 @@ def neptune_instance_iam_authentication_check(
                 "UpdatedAt": iso8601Time,
                 "Severity": {"Label": "INFORMATIONAL"},
                 "Confidence": 99,
-                "Title": "[Neptune.3] Neptune database instaces storage should use IAM Database Authentication",
+                "Title": "[Neptune.3] Neptune database instances storage should use IAM Database Authentication",
                 "Description": "Neptune database instance "
                 + neptuneDbId
                 + " uses IAM Database Authentication.",
@@ -355,7 +355,7 @@ def neptune_instance_iam_authentication_check(
                 "ProductFields": {"Product Name": "Day2SecurityBot"},
                 "Resources": [
                     {
-                        "Type": "Other",
+                        "Type": "AwsNeptuneInstance",
                         "Id": neptuneInstanceArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
@@ -435,7 +435,7 @@ def neptune_cluster_parameter_ssl_enforcement_check(
                         "ProductFields": {"Product Name": "Day2SecurityBot"},
                         "Resources": [
                             {
-                                "Type": "Other",
+                                "Type": "AwsNeptuneParameterGroup",
                                 "Id": parameterGroupArn,
                                 "Partition": awsPartition,
                                 "Region": awsRegion,
@@ -489,7 +489,7 @@ def neptune_cluster_parameter_ssl_enforcement_check(
                         "ProductFields": {"Product Name": "Day2SecurityBot"},
                         "Resources": [
                             {
-                                "Type": "Other",
+                                "Type": "AwsNeptuneParameterGroup",
                                 "Id": parameterGroupArn,
                                 "Partition": awsPartition,
                                 "Region": awsRegion,
@@ -565,7 +565,7 @@ def neptune_cluster_parameter_audit_log_check(
                         "ProductFields": {"Product Name": "Day2SecurityBot"},
                         "Resources": [
                             {
-                                "Type": "Other",
+                                "Type": "AwsNeptuneParameterGroup",
                                 "Id": parameterGroupArn,
                                 "Partition": awsPartition,
                                 "Region": awsRegion,
@@ -618,7 +618,7 @@ def neptune_cluster_parameter_audit_log_check(
                         "ProductFields": {"Product Name": "Day2SecurityBot"},
                         "Resources": [
                             {
-                                "Type": "Other",
+                                "Type": "AwsNeptuneParameterGroup",
                                 "Id": parameterGroupArn,
                                 "Partition": awsPartition,
                                 "Region": awsRegion,

--- a/sbauditor/auditors/aws/Amazon_Neptune_Auditor.py
+++ b/sbauditor/auditors/aws/Amazon_Neptune_Auditor.py
@@ -43,7 +43,7 @@ def neptune_instance_multi_az_check(
                 "UpdatedAt": iso8601Time,
                 "Severity": {"Label": "LOW"},
                 "Confidence": 99,
-                "Title": "[Neptune.1] Neptune database instances should be configured to be highly available",
+                "Title": "[Neptune.1] Neptune database instance should be configured to be highly available",
                 "Description": "Neptune database instance "
                 + neptuneDbId
                 + " does not have Multi-AZ enabled and thus is not highly available. Refer to the remediation instructions to remediate this behavior",
@@ -97,7 +97,7 @@ def neptune_instance_multi_az_check(
                 "UpdatedAt": iso8601Time,
                 "Severity": {"Label": "INFORMATIONAL"},
                 "Confidence": 99,
-                "Title": "[Neptune.1] Neptune database instances should be configured to be highly available",
+                "Title": "[Neptune.1] Neptune database instance should be configured to be highly available",
                 "Description": "Neptune database instance "
                 + neptuneDbId
                 + " is highly available.",
@@ -166,7 +166,7 @@ def neptune_instance_storage_encryption_check(
                 "UpdatedAt": iso8601Time,
                 "Severity": {"Label": "HIGH"},
                 "Confidence": 99,
-                "Title": "[Neptune.2] Neptune database instances storage should be encrypted",
+                "Title": "[Neptune.2] Neptune database instance storage should be encrypted",
                 "Description": "Neptune database instance "
                 + neptuneDbId
                 + " does not have storage encryption enabled. Refer to the remediation instructions to remediate this behavior",
@@ -217,7 +217,7 @@ def neptune_instance_storage_encryption_check(
                 "UpdatedAt": iso8601Time,
                 "Severity": {"Label": "INFORMATIONAL"},
                 "Confidence": 99,
-                "Title": "[Neptune.2] Neptune database instances storage should be encrypted",
+                "Title": "[Neptune.2] Neptune database instance storage should be encrypted",
                 "Description": "Neptune database instance "
                 + neptuneDbId
                 + " has storage encryption enabled.",
@@ -280,7 +280,7 @@ def neptune_instance_iam_authentication_check(
                 "UpdatedAt": iso8601Time,
                 "Severity": {"Label": "MEDIUM"},
                 "Confidence": 99,
-                "Title": "[Neptune.3] Neptune database instances storage should use IAM Database Authentication",
+                "Title": "[Neptune.3] Neptune database instance storage should use IAM Database Authentication",
                 "Description": "Neptune database instance "
                 + neptuneDbId
                 + " does not use IAM Database Authentication. Refer to the remediation instructions to remediate this behavior",
@@ -342,7 +342,7 @@ def neptune_instance_iam_authentication_check(
                 "UpdatedAt": iso8601Time,
                 "Severity": {"Label": "INFORMATIONAL"},
                 "Confidence": 99,
-                "Title": "[Neptune.3] Neptune database instances storage should use IAM Database Authentication",
+                "Title": "[Neptune.3] Neptune database instance storage should use IAM Database Authentication",
                 "Description": "Neptune database instance "
                 + neptuneDbId
                 + " uses IAM Database Authentication.",

--- a/sbauditor/auditors/aws/Amazon_WorkSpaces_Auditor.py
+++ b/sbauditor/auditors/aws/Amazon_WorkSpaces_Auditor.py
@@ -407,7 +407,7 @@ def workspaces_directory_default_internet_check(
                 "ProductFields": {"Product Name": "Day2SecurityBot"},
                 "Resources": [
                     {
-                        "Type": "Other",
+                        "Type": "AwsWorkspacesDirectory",
                         "Id": workspacesDirectoryArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,
@@ -460,7 +460,7 @@ def workspaces_directory_default_internet_check(
                 "ProductFields": {"Product Name": "Day2SecurityBot"},
                 "Resources": [
                     {
-                        "Type": "Other",
+                        "Type": "AwsWorkspacesDirectory",
                         "Id": workspacesDirectoryArn,
                         "Partition": awsPartition,
                         "Region": awsRegion,


### PR DESCRIPTION
Resource type should be AwsEc2Image instead of Other in AMI auditor. Fix same is in many other auditors as well.